### PR TITLE
Refine heartbeat scheduling for background reliability

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -3,8 +3,49 @@ const Status = { IDLE:'idle', GENERATING:'generating', READY:'ready', VIEWED:'vi
 // по вкладкам: { status, ts }
 const tabs = new Map();
 let blinkTimer = null;
+const heartbeatConfigs = new Map(); // tabId -> { intervalMs, staleMs }
+const DEFAULT_STALE_MS = 20000;
+const HEARTBEAT_GRACE_FACTOR = 3;
+const MIN_HEARTBEAT_INTERVAL_MS = 6000;
+const WATCHDOG_ALARM = 'heartbeat-watchdog';
 
-chrome.runtime.onInstalled.addListener(() => chrome.action.setBadgeText({ text: '' }));
+const heartbeatAlarmName = (tabId) => `heartbeat:${tabId}`;
+
+function normalizeInterval(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return MIN_HEARTBEAT_INTERVAL_MS;
+  return Math.max(ms, MIN_HEARTBEAT_INTERVAL_MS);
+}
+
+function scheduleHeartbeatAlarm(tabId, intervalMs) {
+  const normalized = normalizeInterval(intervalMs);
+  const periodInMinutes = Math.max(normalized / 60000, 0.1);
+  const name = heartbeatAlarmName(tabId);
+  chrome.alarms.create(name, {
+    delayInMinutes: periodInMinutes,
+    periodInMinutes,
+  });
+  heartbeatConfigs.set(tabId, {
+    intervalMs: normalized,
+    staleMs: Math.max(normalized * HEARTBEAT_GRACE_FACTOR, DEFAULT_STALE_MS),
+  });
+}
+
+function clearHeartbeat(tabId) {
+  const name = heartbeatAlarmName(tabId);
+  heartbeatConfigs.delete(tabId);
+  chrome.alarms.clear(name, () => { void chrome.runtime.lastError; });
+}
+
+function getStaleMs(tabId) {
+  return heartbeatConfigs.get(tabId)?.staleMs ?? DEFAULT_STALE_MS;
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.action.setBadgeText({ text: '' });
+  chrome.alarms.create(WATCHDOG_ALARM, { periodInMinutes: 0.1 });
+});
+
+chrome.alarms.create(WATCHDOG_ALARM, { periodInMinutes: 0.1 });
 
 chrome.runtime.onMessage.addListener((msg, sender) => {
   if (!sender.tab) return;
@@ -12,6 +53,11 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
 
   if (msg.type === 'status') {
     tabs.set(tabId, { status: msg.status, ts: Date.now() });
+    if (msg.status === Status.GENERATING) {
+      // оставляем расписание heartbeats за контент-скриптом
+    } else {
+      clearHeartbeat(tabId);
+    }
   } else if (msg.type === 'heartbeat') {
     const cur = tabs.get(tabId);
     if (cur?.status === Status.GENERATING) {
@@ -19,6 +65,12 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
       tabs.set(tabId, cur);
     } else {
       tabs.set(tabId, { status: Status.GENERATING, ts: Date.now() });
+    }
+  } else if (msg.type === 'heartbeat-control') {
+    if (msg.action === 'stop') {
+      clearHeartbeat(tabId);
+    } else if (msg.action === 'start' || msg.action === 'update') {
+      scheduleHeartbeatAlarm(tabId, msg.intervalMs);
     }
   } else {
     return;
@@ -42,12 +94,15 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   const onChatGPT = /^https:\/\/(chatgpt\.com|chat\.openai\.com)\//.test(url);
   if (!onChatGPT && tabs.has(tabId)) {
     tabs.delete(tabId);
+    clearHeartbeat(tabId);
     recomputeBadge();
   }
 });
 
 chrome.tabs.onRemoved.addListener((tabId) => {
-  if (tabs.delete(tabId)) recomputeBadge();
+  const removed = tabs.delete(tabId);
+  clearHeartbeat(tabId);
+  if (removed) recomputeBadge();
 });
 
 // клик по иконке — прыгаем на первую вкладку с READY
@@ -57,27 +112,41 @@ chrome.action.onClicked.addListener(() => {
   }
 });
 
-// сторож: если 8 сек нет heartbeat из GENERATING — считаем, что уже не генерит
-const STALE_MS = 8000;
-setInterval(() => {
+function runWatchdog() {
   const now = Date.now();
   let changed = false;
   for (const [tabId, v] of tabs) {
-    if (v.status === Status.GENERATING && now - v.ts > STALE_MS) {
-      tabs.set(tabId, { status: Status.IDLE, ts: now });
-      changed = true;
-      console.log('[BG] stale GENERATING -> IDLE', tabId);
+    if (v.status === Status.GENERATING) {
+      if (now - v.ts > getStaleMs(tabId)) {
+        tabs.set(tabId, { status: Status.IDLE, ts: now });
+        clearHeartbeat(tabId);
+        changed = true;
+        console.log('[BG] stale GENERATING -> IDLE', tabId);
+      }
+    } else if (heartbeatConfigs.has(tabId)) {
+      clearHeartbeat(tabId);
     }
   }
   if (changed) recomputeBadge();
-}, 1000);
+}
+
+runWatchdog();
 
 // глобальный бейдж (READY > GENERATING > пусто)
 function recomputeBadge() {
-  const vals = [...tabs.values()];
   const now = Date.now();
-  const anyReady = vals.some(v => v.status === Status.READY);
-  const anyGenFresh = vals.some(v => v.status === Status.GENERATING && now - v.ts <= STALE_MS);
+  let anyReady = false;
+  let anyGenFresh = false;
+
+  for (const [tabId, v] of tabs) {
+    if (v.status === Status.READY) {
+      anyReady = true;
+      break;
+    }
+    if (v.status === Status.GENERATING && now - v.ts <= getStaleMs(tabId)) {
+      anyGenFresh = true;
+    }
+  }
 
   if (anyReady) { stopBlink(); setBadge('!'); return; }
   if (anyGenFresh) { startBlink(); return; }
@@ -104,3 +173,25 @@ function stopBlink() {
   clearInterval(blinkTimer);
   blinkTimer = null;
 }
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  const name = alarm?.name;
+  if (!name) return;
+  if (name === WATCHDOG_ALARM) {
+    runWatchdog();
+    return;
+  }
+  if (!name.startsWith('heartbeat:')) return;
+  const tabId = Number(name.split(':')[1]);
+  if (!Number.isInteger(tabId) || !heartbeatConfigs.has(tabId)) {
+    chrome.alarms.clear(name, () => { void chrome.runtime.lastError; });
+    return;
+  }
+  try {
+    chrome.tabs.sendMessage(tabId, { type: 'heartbeat-ping' }, () => {
+      void chrome.runtime.lastError;
+    });
+  } catch (_) {
+    clearHeartbeat(tabId);
+  }
+});

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -46,6 +46,72 @@ const notify = (status) => {
   } catch (_) {}
 };
 
+// heartbeat-конфигурация и управление
+const HEARTBEAT_VISIBLE_MS = 6000;
+const HEARTBEAT_HIDDEN_MS  = 9000;
+let   heartbeatActive = false;
+let   heartbeatInterval = null;
+
+const getHeartbeatDelay = () => (
+  document.visibilityState === 'hidden' ? HEARTBEAT_HIDDEN_MS : HEARTBEAT_VISIBLE_MS
+);
+
+const sendHeartbeat = () => {
+  if (state !== Status.GENERATING) return;
+  try {
+    if (chrome?.runtime?.id) {
+      chrome.runtime.sendMessage({ type: 'heartbeat', status: 'generating' }, () => {
+        void chrome.runtime.lastError;
+      });
+    }
+  } catch (_) {}
+};
+
+const startHeartbeat = () => {
+  if (heartbeatActive) return;
+  heartbeatActive = true;
+  sendHeartbeat();
+  heartbeatInterval = getHeartbeatDelay();
+  try {
+    if (chrome?.runtime?.id) {
+      chrome.runtime.sendMessage({
+        type: 'heartbeat-control',
+        action: 'start',
+        intervalMs: heartbeatInterval,
+      }, () => { void chrome.runtime.lastError; });
+    }
+  } catch (_) {}
+};
+
+const stopHeartbeat = () => {
+  if (!heartbeatActive) return;
+  heartbeatActive = false;
+  heartbeatInterval = null;
+  try {
+    if (chrome?.runtime?.id) {
+      chrome.runtime.sendMessage({ type: 'heartbeat-control', action: 'stop' }, () => {
+        void chrome.runtime.lastError;
+      });
+    }
+  } catch (_) {}
+};
+
+const updateHeartbeatSchedule = (force = false) => {
+  if (!heartbeatActive || state !== Status.GENERATING) return;
+  const nextInterval = getHeartbeatDelay();
+  if (!force && heartbeatInterval === nextInterval) return;
+  heartbeatInterval = nextInterval;
+  try {
+    if (chrome?.runtime?.id) {
+      chrome.runtime.sendMessage({
+        type: 'heartbeat-control',
+        action: 'update',
+        intervalMs: heartbeatInterval,
+      }, () => { void chrome.runtime.lastError; });
+    }
+  } catch (_) {}
+};
+
 const scheduleCheck = () => {
   if (checkScheduled) return;
   checkScheduled = true;
@@ -69,11 +135,17 @@ const evaluate = () => {
       };
       console.log('[GPT Badge] START', snapshot);
       notify(Status.GENERATING);
+      startHeartbeat();
+    } else if (!heartbeatActive) {
+      startHeartbeat();
+    } else {
+      updateHeartbeatSchedule();
     }
     return;
   }
 
   if (state === Status.GENERATING) {
+    stopHeartbeat();
     const msgCount = getAssistantNodes().length;
     const lastLen  = getLastAssistantLength();
 
@@ -93,6 +165,7 @@ const evaluate = () => {
       notify(Status.READY);
     } else {
       console.log('[GPT Badge] no change, stay IDLE');
+      notify(Status.IDLE);
     }
   }
 };
@@ -119,6 +192,10 @@ const resetIfViewed = () => {
 window.addEventListener('focus', resetIfViewed);
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'visible') resetIfViewed();
+  if (heartbeatActive && state === Status.GENERATING) {
+    if (document.visibilityState === 'hidden') sendHeartbeat();
+    updateHeartbeatSchedule();
+  }
 });
 
 // резервный поллинг — даже если вкладка в фоне
@@ -129,14 +206,12 @@ setInterval(() => {
   } catch (_) {}
 }, POLL_MS);
 
-// heartbeat — пока GENERATING, пингуем фон, чтобы не «залипали» точки
-const HEARTBEAT_MS = 2000;
-setInterval(() => {
-  try {
-    if (state === Status.GENERATING && chrome?.runtime?.id) {
-      chrome.runtime.sendMessage({ type: 'heartbeat', status: 'generating' }, () => {
-        void chrome.runtime.lastError;
-      });
+// слушаем пинги из background, чтобы heartbeat не залипал в фоне
+try {
+  chrome?.runtime?.onMessage?.addListener((msg) => {
+    if (msg?.type === 'heartbeat-ping' && heartbeatActive && state === Status.GENERATING) {
+      sendHeartbeat();
+      updateHeartbeatSchedule();
     }
-  } catch (_) {}
-}, HEARTBEAT_MS);
+  });
+} catch (_) {}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "ChatGPT Tab Notifier",
   "description": "Highlights the ChatGPT tab when a response is ready.",
   "version": "1.0.0",
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "alarms"],
 
   "host_permissions": [
     "https://chatgpt.com/*",


### PR DESCRIPTION
## Summary
- replace the content-script heartbeat loop with a visibility-aware schedule that coordinates with the background worker via heartbeat-control messages
- drive background heartbeats using chrome.alarms, track per-tab intervals, and compute stale timeouts dynamically based on the configured cadence
- add an alarms permission and a watchdog alarm so badge blinking and idle transitions stay accurate while tabs are hidden

## Testing
- not run (extension has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68cc6fe09028832e96098c0b16cc36ce